### PR TITLE
Add support for Spinnaker cluster-contexts - kubectl like

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ swinch help
 Available Commands:
   apply       Apply or sync an Application or Pipeline from a manifest
   completion  Generate shell completion script
+  config      Tweak swinch config
   delete      Delete the Application or Pipeline form a manifest
   help        Help about any command
   import      Import a chart from spinnaker

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -16,20 +16,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// importCmd represents the import command
-var importCmd = &cobra.Command{
-	Use:   "import",
-	Short: "Import a chart from spinnaker",
-	Long:  `Import a chart from spinnaker`,
+// configCmd represents the config command
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Tweak swinch config",
+	Long:  `Tweak swinch config - setup is similar with kubernetes kubeconfig; one can easily define multiple contexts and switch between them`,
+	Example: `Steps to initialize a custom config:
+	swinch config generate (generates a mock config file with some example entries)
+	swinch config add-context (add a new real context)
+	swinch config use-context (select the real context to use)
+	swinch config delete-context (delete the example entries)`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		SetLogLevel(logLevel)
+
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// import only used with additional child commands
 		cmd.Help()
 	},
 }
 
 func init() {
-	rootCmd.AddCommand(importCmd)
+	rootCmd.AddCommand(configCmd)
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+package config
+
+import (
+	"encoding/base64"
+	"github.com/manifoldco/promptui"
+	"github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"swinch/domain"
+)
+
+const (
+	CfgFolderName = "/.swinch/"
+	CfgFolderPerm = 0700
+
+	CfgFileName = "config.yaml"
+	CfgFilePerm = 0600
+
+	CfgSpinFileName = "context-spin-config.yaml"
+	CfgSpinFilePerm = 0600
+)
+
+type SpinConfigFile struct {
+	Gate struct {
+		Endpoint string `yaml:"endpoint"`
+	} `yaml:"gate"`
+
+	Auth struct {
+		Enabled bool `yaml:"enabled"`
+		Ldap    struct {
+			Username string `yaml:"username"`
+			Password string `yaml:"password"`
+		} `yaml:"ldap,omitempty"`
+		Basic struct {
+			Username string `yaml:"username"`
+			Password string `yaml:"password"`
+		} `yaml:"basic,omitempty"`
+	} `yaml:"auth"`
+}
+
+type ContextDefinition struct {
+	Name     string
+	Endpoint string
+	Auth     string
+	Username string
+	Password string
+}
+
+type CurrentContext struct {
+	Name string
+}
+
+type CPrompt struct {
+	PUI       promptui.Prompt
+	FieldName string
+}
+
+func (scf SpinConfigFile) GenerateSpinConfigFile() {
+	cd := ContextDefinition{}
+	ctx, _ := cd.GetContexts()
+
+	cc := CurrentContext{}
+	currentCtx := cc.GetCurrentContext()
+
+	var cfg SpinConfigFile
+
+	for _, context := range ctx {
+		if context.Name == currentCtx {
+			cfg.Gate.Endpoint = context.Endpoint
+			cfg.Auth.Enabled = true
+
+			switch context.Auth {
+			case "ldap":
+				cfg.Auth.Ldap.Username = context.Username
+				cfg.Auth.Ldap.Password = Base64Actions("decode", context.Password)
+			case "basic":
+				cfg.Auth.Basic.Username = context.Username
+				cfg.Auth.Basic.Password = Base64Actions("decode", context.Password)
+			}
+		}
+	}
+
+	ds := domain.Datastore{}
+	spinCfgFile := ds.MarshalYAML(&cfg)
+	ds.WriteFile(HomeFolder()+CfgFolderName+CfgSpinFileName, spinCfgFile, CfgSpinFilePerm)
+}
+
+func (cd ContextDefinition) GetContexts() ([]ContextDefinition, []string) {
+	var ctx []ContextDefinition
+	var ctxList []string
+
+	if err := viper.UnmarshalKey("contexts", &ctx); err != nil {
+		log.Fatalf("Error reading contexts: %s", err)
+		return nil, nil
+	} else {
+		// ctxList string slice needed by promptui; adding to list only contexts with all the fields set
+		for _, v := range ctx {
+			if v.Name != "" && v.Endpoint != "" && v.Auth != "" && v.Username != "" && v.Password != "" {
+				ctxList = append(ctxList, v.Name)
+			}
+		}
+		return ctx, ctxList
+	}
+}
+
+func (cc CurrentContext) GetCurrentContext() string {
+	var currentCtx CurrentContext
+	if err := viper.UnmarshalKey("current-context", &currentCtx); err != nil {
+		log.Fatalf("Error reading current context: %s", err)
+		return ""
+	} else {
+		return currentCtx.Name
+	}
+}
+
+func Base64Actions(action, data string) string {
+	switch action {
+	case "encode":
+		encodedData := base64.StdEncoding.EncodeToString([]byte(data))
+		return encodedData
+	case "decode":
+		decodedData, err := base64.StdEncoding.DecodeString(data)
+		if err != nil {
+			log.Fatalf("Error decoding data: %s", err)
+			return ""
+		} else {
+			return string(decodedData)
+		}
+	default:
+		return ""
+	}
+}
+
+// ValidateCurrentContext function validates that 'current-context' exists in the contexts list and it is valid (all fields populated); returns bool type
+func ValidateCurrentContext() bool {
+	cd := ContextDefinition{}
+	_, ctxList := cd.GetContexts()
+
+	cc := CurrentContext{}
+	currentCtx := cc.GetCurrentContext()
+
+	contextExists := false
+
+	for _, context := range ctxList {
+		if currentCtx == context {
+			contextExists = true
+		}
+	}
+
+	return contextExists
+}
+
+func HomeFolder() string {
+	home, err := homedir.Dir()
+	if err != nil {
+		log.Fatalf("Error establishing the home directory: %s", err)
+		return ""
+	} else {
+		return home
+	}
+}

--- a/cmd/config_add_context.go
+++ b/cmd/config_add_context.go
@@ -154,7 +154,7 @@ func addNewContext(fields map[string]string) {
 		Endpoint: fields["endpoint"],
 		Auth:     fields["auth"],
 		Username: fields["username"],
-		Password: config.Base64Actions("encode", fields["password"]),
+		Password: config.Base64Encode(fields["password"]),
 	}
 
 	ctx = append(ctx, newContext)

--- a/cmd/config_add_context.go
+++ b/cmd/config_add_context.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"github.com/manifoldco/promptui"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"os/user"
+	"swinch/cmd/config"
+)
+
+// addContextCmd represents the add-context command
+var addContextCmd = &cobra.Command{
+	Use:   "add-context",
+	Short: "Adds a new Spinnaker context to the config file",
+	Long:  `Adds a new Spinnaker context to the config file`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		SetLogLevel(logLevel)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := viper.ReadInConfig(); err == nil {
+			fields := addContextPromptUI()
+			if fields["confirmation"] == "y" {
+				addNewContext(fields)
+			}
+		}
+	},
+}
+
+func init() {
+	configCmd.AddCommand(addContextCmd)
+}
+
+func addContextPromptUI() map[string]string {
+	// Retrieve the current user for autocompletion purposes
+	username := ""
+	u, err := user.Current()
+	if err == nil {
+		username = u.Username
+	}
+
+	// Prompt validations
+	validateContextDuplication := func(input string) error {
+		cd := config.ContextDefinition{}
+		ctx, _ := cd.GetContexts()
+
+		if len(input) < 3 {
+			return errors.New("must use at least 3 characters")
+		} else {
+			for _, v := range ctx {
+				if input == v.Name {
+					return errors.New("context already exists, choose a different name OR delete the entry and retry")
+				}
+			}
+		}
+		return nil
+	}
+
+	validateAuth := func(input string) error {
+		if input != "ldap" && input != "basic" {
+			return errors.New("must use ether 'ldap' OR 'basic' auth methods")
+		}
+		return nil
+	}
+
+	validateFieldLength := func(input string) error {
+		if len(input) < 3 {
+			return errors.New("must use at least 3 characters")
+		}
+		return nil
+	}
+
+	fields := map[string]string{}
+
+	prompts := []config.CPrompt{
+		{
+			PUI: promptui.Prompt{
+				Label:    "Spinnaker context name",
+				Default:  "spinnaker-prod",
+				Validate: validateContextDuplication,
+			},
+			FieldName: "name",
+		},
+		{
+			PUI: promptui.Prompt{
+				Label:    "Spinnaker API endpoint",
+				Default:  "https://spinnaker-prod-api.example.com",
+				Validate: validateFieldLength,
+			},
+			FieldName: "endpoint",
+		},
+		{
+			PUI: promptui.Prompt{
+				Label:    "Auth type (ldap OR basic)",
+				Default:  "ldap",
+				Validate: validateAuth,
+			},
+			FieldName: "auth",
+		},
+		{
+			PUI: promptui.Prompt{
+				Label:    "Username",
+				Default:  username,
+				Validate: validateFieldLength,
+			},
+			FieldName: "username",
+		},
+		{
+			PUI: promptui.Prompt{
+				Label:    "Password (hidden-base64encoded)",
+				Mask:     '*',
+				Validate: validateFieldLength,
+			},
+			FieldName: "password",
+		},
+		{
+			PUI: promptui.Prompt{
+				Label:     "Is the information above correct",
+				IsConfirm: true,
+			},
+			FieldName: "confirmation",
+		},
+	}
+
+	for _, prompt := range prompts {
+		fields[prompt.FieldName], err = prompt.PUI.Run()
+		if err != nil {
+			log.Errorf("Exiting... %v\n", err)
+			break
+		}
+	}
+	return fields
+}
+
+func addNewContext(fields map[string]string) {
+	cd := config.ContextDefinition{}
+	ctx, _ := cd.GetContexts()
+
+	newContext := config.ContextDefinition{
+		Name:     fields["name"],
+		Endpoint: fields["endpoint"],
+		Auth:     fields["auth"],
+		Username: fields["username"],
+		Password: config.Base64Actions("encode", fields["password"]),
+	}
+
+	ctx = append(ctx, newContext)
+
+	viper.Set("contexts", ctx)
+
+	err := viper.WriteConfig()
+	if err != nil {
+		log.Errorf("Error: %s", err)
+	} else {
+		log.Infof("New context '%s' was added to the config file; you can now run `swinch config use-context` to set it as current-context", fields["name"])
+	}
+}

--- a/cmd/config_delete_context.go
+++ b/cmd/config_delete_context.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/manifoldco/promptui"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"swinch/cmd/config"
+)
+
+// deleteContextCmd represents the delete-context command
+var deleteContextCmd = &cobra.Command{
+	Use:   "delete-context",
+	Short: "Deletes a Spinnaker context from the config file",
+	Long:  `Deletes a Spinnaker context from the config file`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		SetLogLevel(logLevel)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := viper.ReadInConfig(); err == nil {
+			context := deleteContextPromptUI()
+			if context != "" {
+				deleteContext(context)
+			}
+		}
+	},
+}
+
+func init() {
+	configCmd.AddCommand(deleteContextCmd)
+}
+
+func deleteContextPromptUI() string {
+	cd := config.ContextDefinition{}
+	_, ctxList := cd.GetContexts()
+
+	if len(ctxList) > 0 {
+		prompt := promptui.Select{
+			Label: "Delete Spinnaker Context",
+			Items: ctxList,
+		}
+		_, context, err := prompt.Run()
+		if err != nil {
+			log.Errorf("Exiting %v\n", err)
+			return ""
+		} else {
+			return context
+		}
+	} else {
+		log.Errorf("The config file does not have any valid contexts")
+		return ""
+	}
+}
+
+func deleteContext(context string) {
+	cd := config.ContextDefinition{}
+	ctx, _ := cd.GetContexts()
+
+	cc := config.CurrentContext{}
+	currentCtx := cc.GetCurrentContext()
+
+	var updatedCtx []config.ContextDefinition
+
+	// Removing the context selected for deletion from the contexts list in the new updatedCtx slice
+	for _, v := range ctx {
+		if v.Name != context {
+			updatedCtx = append(updatedCtx, v)
+		}
+	}
+
+	viper.Set("contexts", updatedCtx)
+
+	err := viper.WriteConfig()
+	if err != nil {
+		log.Errorf("Error: %s", err)
+	} else {
+		if context == currentCtx {
+			log.Warnf("Context '%s' selected for deletion is set as 'current-context'; run 'swinch config use-context' to select another current-context", context)
+		} else {
+			log.Infof("Context '%s' was deleted from the config file", context)
+		}
+	}
+}

--- a/cmd/config_delete_context.go
+++ b/cmd/config_delete_context.go
@@ -46,22 +46,19 @@ func deleteContextPromptUI() string {
 	cd := config.ContextDefinition{}
 	_, ctxList := cd.GetContexts()
 
-	if len(ctxList) > 0 {
-		prompt := promptui.Select{
-			Label: "Delete Spinnaker Context",
-			Items: ctxList,
-		}
-		_, context, err := prompt.Run()
-		if err != nil {
-			log.Errorf("Exiting %v\n", err)
-			return ""
-		} else {
-			return context
-		}
-	} else {
-		log.Errorf("The config file does not have any valid contexts")
-		return ""
+	if len(ctxList) == 0 {
+		log.Fatalf("The config file does not have any valid contexts")
 	}
+
+	prompt := promptui.Select{
+		Label: "Delete Spinnaker Context",
+		Items: ctxList,
+	}
+	_, context, err := prompt.Run()
+	if err != nil {
+		log.Fatalf("Exiting %v\n", err)
+	}
+	return context
 }
 
 func deleteContext(context string) {

--- a/cmd/config_generate.go
+++ b/cmd/config_generate.go
@@ -45,14 +45,14 @@ func generateConfig() {
 			Endpoint: "https://spinnaker-dev-api.example.com",
 			Auth:     "ldap",
 			Username: "username",
-			Password: config.Base64Actions("encode", "base64EncodedPassword"),
+			Password: config.Base64Encode("base64EncodedPassword"),
 		},
 		{
 			Name:     "spinnaker-prod",
 			Endpoint: "https://spinnaker-prod-api.example.com",
 			Auth:     "basic",
 			Username: "username",
-			Password: config.Base64Actions("encode", "base64EncodedPassword"),
+			Password: config.Base64Encode("base64EncodedPassword"),
 		},
 	}
 

--- a/cmd/config_generate.go
+++ b/cmd/config_generate.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+package cmd
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"path"
+	"swinch/cmd/config"
+	"swinch/domain"
+)
+
+// generateCmd represents the generate command
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generates a mock swinch config file in '~/.swinch/config.yaml'",
+	Long:  `Generates a mock swinch config file in '~/.swinch/config.yaml'`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		SetLogLevel(logLevel)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		generateConfig()
+	},
+}
+
+func init() {
+	configCmd.AddCommand(generateCmd)
+}
+
+func generateConfig() {
+	contexts := []config.ContextDefinition{
+		{
+			Name:     "spinnaker-dev",
+			Endpoint: "https://spinnaker-dev-api.example.com",
+			Auth:     "ldap",
+			Username: "username",
+			Password: config.Base64Actions("encode", "base64EncodedPassword"),
+		},
+		{
+			Name:     "spinnaker-prod",
+			Endpoint: "https://spinnaker-prod-api.example.com",
+			Auth:     "basic",
+			Username: "username",
+			Password: config.Base64Actions("encode", "base64EncodedPassword"),
+		},
+	}
+
+	currentContext := config.CurrentContext{Name: "spinnaker-dev"}
+
+	// Populate the generated config file with some mock values and set secure file permissions
+	viper.SetDefault("contexts", contexts)
+	viper.SetDefault("current-context", currentContext)
+	viper.SetConfigPermissions(config.CfgFilePerm)
+
+	// Write the config file to the default location ~/.swinch/config.yaml
+	ds := domain.Datastore{}
+	ds.Mkdir(path.Join(config.HomeFolder(), config.CfgFolderName), config.CfgFolderPerm)
+
+	err := viper.SafeWriteConfigAs(config.HomeFolder() + config.CfgFolderName + config.CfgFileName)
+	if err != nil {
+		log.Fatalf("Error: %s", err)
+	} else {
+		log.Infof("Writing a mock swinch config file in: %s",
+			config.HomeFolder()+config.CfgFolderName+config.CfgFileName+
+				" \nNow run 'swinch config add-context' to append a real context to the config file and then 'swinch config use-context' to set it as current context")
+	}
+}

--- a/cmd/config_use_context.go
+++ b/cmd/config_use_context.go
@@ -46,22 +46,19 @@ func useContextPromptUI() string {
 	cd := config.ContextDefinition{}
 	_, ctxList := cd.GetContexts()
 
-	if len(ctxList) > 0 {
-		prompt := promptui.Select{
-			Label: "Set a new Spinnaker Context",
-			Items: ctxList,
-		}
-		_, context, err := prompt.Run()
-		if err != nil {
-			log.Errorf("Exiting %v\n", err)
-			return ""
-		} else {
-			return context
-		}
-	} else {
-		log.Errorf("The config file does not have any valid contexts")
-		return ""
+	if len(ctxList) == 0 {
+		log.Fatalf("The config file does not have any valid contexts")
 	}
+
+	prompt := promptui.Select{
+		Label: "Set a new Spinnaker Context",
+		Items: ctxList,
+	}
+	_, context, err := prompt.Run()
+	if err != nil {
+		log.Fatalf("Exiting %v\n", err)
+	}
+	return context
 }
 
 func changeCurrentContext(newContext string) {

--- a/cmd/config_use_context.go
+++ b/cmd/config_use_context.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+package cmd
+
+import (
+	"github.com/manifoldco/promptui"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"swinch/cmd/config"
+)
+
+// useContextCmd represents the use-context command
+var useContextCmd = &cobra.Command{
+	Use:   "use-context",
+	Short: "Switches between Spinnaker contexts",
+	Long:  `Switches between Spinnaker contexts`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		SetLogLevel(logLevel)
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := viper.ReadInConfig(); err == nil {
+			context := useContextPromptUI()
+			if context != "" {
+				changeCurrentContext(context)
+			}
+		}
+	},
+}
+
+func init() {
+	configCmd.AddCommand(useContextCmd)
+}
+
+func useContextPromptUI() string {
+	cd := config.ContextDefinition{}
+	_, ctxList := cd.GetContexts()
+
+	if len(ctxList) > 0 {
+		prompt := promptui.Select{
+			Label: "Set a new Spinnaker Context",
+			Items: ctxList,
+		}
+		_, context, err := prompt.Run()
+		if err != nil {
+			log.Errorf("Exiting %v\n", err)
+			return ""
+		} else {
+			return context
+		}
+	} else {
+		log.Errorf("The config file does not have any valid contexts")
+		return ""
+	}
+}
+
+func changeCurrentContext(newContext string) {
+	viper.Set("current-context.name", newContext)
+
+	err := viper.WriteConfig()
+	if err != nil {
+		log.Errorf("Error: %s", err)
+	} else {
+		log.Infof("Current context is now set to: '%s'", newContext)
+	}
+
+	scf := config.SpinConfigFile{}
+	scf.GenerateSpinConfigFile()
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -89,7 +89,7 @@ func initConfig() {
 			log.Debugf("Using config file: '%s' with current-context as '%s'", viper.ConfigFileUsed(), viper.Get("current-context.name"))
 			contextExists := config.ValidateCurrentContext()
 			if contextExists != true {
-				log.Fatalf("The context set as current-context '%s' is not valid (missing fields) OR does not exist in the contexts list; run 'swinch config use-context' to select a valid context", viper.Get("current-context.name"))
+				log.Errorf("The context set as current-context '%s' is not valid (missing fields) OR does not exist in the contexts list; run 'swinch config use-context' to select a valid context", viper.Get("current-context.name"))
 			}
 		} else {
 			log.Fatalf("A parsing error detected in '%s': '%s'", viper.ConfigFileUsed(), err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,16 +13,15 @@ governing permissions and limitations under the License.
 package cmd
 
 import (
-	"fmt"
-	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"os"
+	"swinch/cmd/config"
+	"swinch/domain"
 )
 
 var (
-	cfgFile         string
 	logLevel        string
 	plan            bool
 	filePath        string
@@ -48,7 +47,9 @@ var rootCmd = &cobra.Command{
 
 	Short: "Generate Spinnaker applications and pipelines from a kubernetes like objects",
 	Long:  "Generate Spinnaker applications and pipelines from a kubernetes like objects",
-	Run:   func(cmd *cobra.Command, args []string) { fmt.Println("Try the -h flag for possible options") },
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -61,10 +62,7 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.swinch.yaml)")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "verbosity", "v", log.InfoLevel.String(), "Log level (debug, info, warn, error, fatal, panic")
-
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }
 
 // SetLogLevel set the log level
@@ -75,23 +73,37 @@ func SetLogLevel(logLevel string) {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory with name ".swinch" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".swinch")
-	}
+	// Search config in "~/.swinch/config.yaml".
+	viper.AddConfigPath(config.HomeFolder() + config.CfgFolderName)
+	viper.SetConfigName("config.yaml")
+	viper.SetConfigType("yaml")
 
 	viper.AutomaticEnv() // read in environment variables that match
 
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
+	ds := domain.Datastore{}
+
+	switch ds.FileExists(config.HomeFolder() + config.CfgFolderName + config.CfgFileName) {
+	case true:
+		// If a config file is found, read it in and validate current-context against available contexts
+		if err := viper.ReadInConfig(); err == nil {
+			log.Debugf("Using config file: '%s' with current-context as '%s'", viper.ConfigFileUsed(), viper.Get("current-context.name"))
+			contextExists := config.ValidateCurrentContext()
+			if contextExists != true {
+				log.Fatalf("The context set as current-context '%s' is not valid (missing fields) OR does not exist in the contexts list; run 'swinch config use-context' to select a valid context", viper.Get("current-context.name"))
+			}
+		} else {
+			log.Fatalf("A parsing error detected in '%s': '%s'", viper.ConfigFileUsed(), err)
+		}
+	case false:
+		// If no config file is found, allow only the 'swinch config generate' command
+		_, str, _ := rootCmd.Find(os.Args)
+
+		if len(str) == 3 {
+			if str[1] != "config" || str[2] != "generate" {
+				log.Fatalf("Config file not found, please generate and adapt one (see 'swinch config generate -h')")
+			}
+		} else {
+			log.Fatalf("Config file not found, please generate and adapt one (see 'swinch config generate -h')")
+		}
 	}
 }

--- a/domain/applicationManifest.go
+++ b/domain/applicationManifest.go
@@ -41,7 +41,7 @@ type ApplicationMetadata struct {
 
 func (am *ApplicationManifest) LoadManifest(manifest interface{}) {
 	d := Datastore{}
-	err := yaml.Unmarshal(d.marshalYAML(manifest), &am)
+	err := yaml.Unmarshal(d.MarshalYAML(manifest), &am)
 	if err != nil {
 		log.Fatalf("Error LoadManifest: %v", err)
 	}

--- a/domain/chart.go
+++ b/domain/chart.go
@@ -35,10 +35,10 @@ type Chart struct {
 // Import
 
 func (c Chart) GenerateChart(manifest interface{}) {
-	if c.fileExists(path.Join(c.OutputPath, c.ChartMetadata.Name, ChartValuesFile)) && c.ProtectedImport {
+	if c.FileExists(path.Join(c.OutputPath, c.ChartMetadata.Name, ChartValuesFile)) && c.ProtectedImport {
 		log.Fatalf("Cannot import over an existing chart, values file present in path '%s'", path.Join(c.OutputPath, c.ChartMetadata.Name, ChartValuesFile))
 	} else {
-		c.Mkdir(path.Join(c.OutputPath, c.ChartMetadata.Name, "/", ChartTemplatesFolder))
+		c.Mkdir(path.Join(c.OutputPath, c.ChartMetadata.Name, "/", ChartTemplatesFolder), FilePerm)
 		c.WriteChartMetadata()
 		c.WriteChartValues()
 		c.WriteManifest(manifest)

--- a/domain/chartTemplate.go
+++ b/domain/chartTemplate.go
@@ -43,7 +43,7 @@ func (t Template) RenderChart(chartPath, valuesFile, outputPath string) {
 		}
 
 		d := Datastore{}
-		d.Mkdir(path.Join(outputPath))
+		d.Mkdir(path.Join(outputPath), FilePerm)
 		outFile, err := os.Create(path.Join(outputPath, chartFile.Name()))
 		if err != nil {
 			log.Fatalf("Error in output files: %v", err)

--- a/domain/datastore.go
+++ b/domain/datastore.go
@@ -111,7 +111,7 @@ func (d Datastore) ReadYAMLDocs(yamlFilesBuffer *bytes.Buffer) ([]ApplicationMan
 
 func (d Datastore) WriteJSON(data interface{}, outputPath string) {
 	byteData := d.MarshalJSON(data)
-	d.writeFile(outputPath, byteData)
+	d.WriteFile(outputPath, byteData, FilePerm)
 }
 
 func (d Datastore) WriteJSONTmp(data interface{}) (filePath string) {
@@ -120,8 +120,8 @@ func (d Datastore) WriteJSONTmp(data interface{}) (filePath string) {
 }
 
 func (d Datastore) WriteYAML(data interface{}, outputPath string) {
-	byteData := d.marshalYAML(data)
-	d.writeFile(outputPath, byteData)
+	byteData := d.MarshalYAML(data)
+	d.WriteFile(outputPath, byteData, FilePerm)
 }
 
 // Utils
@@ -143,7 +143,7 @@ func (d Datastore) UnmarshalJSON(data []byte) []byte {
 	return *buffer
 }
 
-func (d *Datastore) marshalYAML(data interface{}) []byte {
+func (d *Datastore) MarshalYAML(data interface{}) []byte {
 	byteData := new(bytes.Buffer)
 	yamlEncoder := yaml.NewEncoder(byteData)
 	yamlEncoder.SetIndent(2)
@@ -191,25 +191,25 @@ func (d Datastore) ReadFile(filePath string) []byte {
 	return byteData
 }
 
-func (d Datastore) writeFile(outputPath string, byteData []byte) {
+func (d Datastore) WriteFile(outputPath string, byteData []byte, perm int) {
 	filePath := path.Join(outputPath)
-	err := os.WriteFile(filePath, byteData, FilePerm)
+	err := os.WriteFile(filePath, byteData, os.FileMode(perm))
 	if err != nil {
 		log.Fatalf("Failed to write:  %v in path: %v", err, filePath)
 		log.Debugf("Writing: %v", byteData)
 	}
 }
 
-func (d Datastore) Mkdir(path string) {
+func (d Datastore) Mkdir(path string, perm int) {
 	if _, errStat := os.Stat(path); os.IsNotExist(errStat) {
-		err := os.MkdirAll(path, FilePerm)
+		err := os.MkdirAll(path, os.FileMode(perm))
 		if err != nil {
 			log.Fatalf("Error mkdir:  %v", err)
 		}
 	}
 }
 
-func (d Datastore) fileExists(path string) bool {
+func (d Datastore) FileExists(path string) bool {
 	if _, errStat := os.Stat(path); os.IsNotExist(errStat) {
 		return false
 	} else {

--- a/domain/pipelineManifest.go
+++ b/domain/pipelineManifest.go
@@ -41,7 +41,7 @@ type PipelineMetadata struct {
 
 func (pm *PipelineManifest) LoadManifest(manifest interface{}) {
 	d := Datastore{}
-	err := yaml.Unmarshal(d.marshalYAML(manifest), &pm)
+	err := yaml.Unmarshal(d.MarshalYAML(manifest), &pm)
 	if err != nil {
 		log.Fatalf("Error LoadManifest: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/manifoldco/promptui v0.8.0
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
-github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
+github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
@@ -204,14 +204,9 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-<<<<<<< HEAD
-github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
-=======
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
-github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
->>>>>>> Add support for Spinnaker cluster-context - kubectl like
+github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -222,8 +217,8 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
-github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
+github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/manifoldco/promptui v0.8.0 h1:R95mMF+McvXZQ7j1g8ucVZE1gLP3Sv6j9vlF9kyRqQo=
 github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEXGwov2nIKuGQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
@@ -444,6 +439,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -58,10 +58,13 @@ github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
-github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -201,7 +204,14 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+<<<<<<< HEAD
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
+=======
+github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
+github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
+github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
+>>>>>>> Add support for Spinnaker cluster-context - kubectl like
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -209,13 +219,18 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
+github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
-github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
+github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
+github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/manifoldco/promptui v0.8.0 h1:R95mMF+McvXZQ7j1g8ucVZE1gLP3Sv6j9vlF9kyRqQo=
+github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEXGwov2nIKuGQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9 h1:d5US/mDsogSGW37IV293h//ZFaeajb69h+EHFsv2xGg=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=

--- a/spincli/application.go
+++ b/spincli/application.go
@@ -15,6 +15,7 @@ package spincli
 import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
+	"swinch/cmd/config"
 )
 
 type ApplicationAPI struct {
@@ -24,6 +25,7 @@ type ApplicationAPI struct {
 
 var baseArgs = []string{
 	"--no-color=false",
+	"--config", config.HomeFolder()+config.CfgFolderName+config.CfgSpinFileName,
 }
 
 func (a *ApplicationAPI) NotFound() error {
@@ -31,7 +33,7 @@ func (a *ApplicationAPI) NotFound() error {
 }
 
 func (a *ApplicationAPI) deleteNotFound() error {
-	return fmt.Errorf("Attempting to delete application '%v' which does not exist, exiting...", a.App)
+	return fmt.Errorf("attempting to delete application '%v' which does not exist, exiting", a.App)
 }
 
 func (a *ApplicationAPI) Get() []byte {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support for cluster-contexts (kubectl-like) for easy switching between contexts when working with multiple Spinnaker clusters.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Make it easier to switch between multiple Spinnaker clusters; after running swinch config add-context and all your contexts are registered, one can switch between them with a simple interactive swinch config use-context command.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
